### PR TITLE
Change sourcemaps format slightly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.vscode/
 temp/

--- a/source_maps/simulation_worker.bundle.json
+++ b/source_maps/simulation_worker.bundle.json
@@ -1,26 +1,38 @@
 [
   {
-    "original": "e:2:0",
-    "modified": "modules:2:0"
+    "original": "e",
+    "modified": "modules",
+    "scope_id": 3,
+    "id": 0
   },
   {
-    "original": "t:2:131",
-    "modified": "moduleRequireCache:2:131"
+    "original": "t",
+    "modified": "moduleRequireCache",
+    "scope_id": 2,
+    "id": 131
   },
   {
-    "original": "n:2:132",
-    "modified": "require:2:132"
+    "original": "n",
+    "modified": "require",
+    "scope_id": 2,
+    "id": 132
   },
   {
-    "original": "r:3:134",
-    "modified": "cacheHit:3:134"
+    "original": "r",
+    "modified": "cacheHit",
+    "scope_id": 3,
+    "id": 134
   },
   {
-    "original": "a:3:135",
-    "modified": "module:3:135"
+    "original": "a",
+    "modified": "module",
+    "scope_id": 3,
+    "id": 135
   },
   {
-    "original": "i:2:133",
-    "modified": "id:2:133"
+    "original": "i",
+    "modified": "id",
+    "scope_id": 2,
+    "id": 133
   }
 ]

--- a/source_maps/simulation_worker.bundle.json
+++ b/source_maps/simulation_worker.bundle.json
@@ -2,7 +2,7 @@
   {
     "original": "e",
     "modified": "modules",
-    "scope_id": 3,
+    "scope_id": 2,
     "id": 0
   },
   {

--- a/tools/imap/src/main.rs
+++ b/tools/imap/src/main.rs
@@ -45,6 +45,8 @@ enum Commands {
 struct Mapping {
     original: String,
     modified: String,
+    scope_id: u32,
+    id: usize,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -116,12 +118,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         for (orig, modif) in only_in_original.iter().zip(only_in_modified.iter()) {
                             println!(
                                 "→ Identifier change in {:?}: '{}' → '{}'",
-                                file, orig, modif
+                                file, orig.0, modif.0
                             );
 
                             mappings_new.push(Mapping {
-                                original: orig.clone(),
-                                modified: modif.clone(),
+                                original: orig.0.clone(),
+                                modified: modif.0.clone(),
+                                scope_id: orig.1,
+                                id: orig.2,
                             });
                         }
 

--- a/tools/imap/src/visitor.rs
+++ b/tools/imap/src/visitor.rs
@@ -4,14 +4,14 @@ use oxc_syntax::scope::ScopeFlags;
 
 #[derive(Debug, Default)]
 pub struct IdentifierCollector {
-    pub identifiers: Vec<String>,
+    pub identifiers: Vec<(String, u32, usize)>,
     current_scope: u32,
 }
 
 impl IdentifierCollector {
-    fn get_identifier_name(&self, name: String) -> String {
+    fn get_identifier_name(&self, name: String) -> (String, u32, usize) {
         // We do this to avoid name collisions
-        format!("{}:{}:{}", name, self.current_scope, self.identifiers.len())
+        (name, self.current_scope, self.identifiers.len())
     }
 }
 


### PR DESCRIPTION
- Scope ID and unique ID are common for both original and modified identifiers, so they're moved into their own field.
- Manually updated `source_maps/simulation_worker.bundle.json` to new format by hand.
- Apply some clippy suggestions.